### PR TITLE
Add Python 3 to language classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,11 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.5",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Security"
     ],


### PR DESCRIPTION
Without Python 3 listed as a language classifer the project gets marked as not supported Python 3 when using tools like [caniusepython3.com](https://caniusepython3.com) to check Python 3 compatibility.

Can't tell from this repo which specific versions of Python 3 should be marked as supported so I've only added just Python 3 (and added a classifier to clarify general Python 2 support). The more specific versions should be added for clarity.