### PR TITLE
Clarify onetouch approval status and added get_approval method

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ To generate a OneTouch approval request which user can accept or reject on Authy
 If you want to check status (accepted/rejected) of OneTouch approval request UUID
 
 Use the get_approval() method or use \_\_getitem\_\_ method buried in object instance class.
+get_approval retuns None (status key in approval_request not found),pending,approved,denied
 
     approval_status = authy_api.one_touch.get_approval_status(UUID)
     if approval_status.ok(): #This only returns True if the response code is 200

--- a/README.md
+++ b/README.md
@@ -222,10 +222,19 @@ To generate a OneTouch approval request which user can accept or reject on Authy
 ### Check OneTouch UUID status
 If you want to check status (accepted/rejected) of OneTouch approval request UUID
 
+Use the get_approval() method or use \_\_getitem\_\_ method buried in object instance class.
+
     approval_status = authy_api.one_touch.get_approval_status(UUID)
-    if status_response.ok():
-        # do your stuff.
-        status = approval_status.status()
+    if approval_status.ok(): #This only returns True if the response code is 200
+        status = approval_status.status() #This is misleading. It returns the request status not approval status
+                                          #Hopefully no one is using this for any validation.
+
+        if approval_status.get_approval() == 'approved':
+            print('do stuff')
+
+       ###Or
+       #if approval_status.__getitem__('approval_request')['status'] == 'approved':
+       #    print('do stuff')  
     else:
         # do your stuff, may be you want to ignore this.
 

--- a/authy/api/resources.py
+++ b/authy/api/resources.py
@@ -375,15 +375,25 @@ class OneTouchResponse(Instance):
         :param response of OneTouch datatype:
         """
         self.uuid = None
+        self.approval = None
         super(OneTouchResponse, self).__init__(resource, response)
         if (isinstance(self.content, dict) and 'approval_request' in self.content):
             self.uuid = self.content['approval_request']['uuid']
+            if 'status' in self.content['approval_request']:
+                self.approval = self.content['approval_request'].get('status')
 
 
     def get_uuid(self):
         if not self.uuid:
             return False
         return self.uuid
+
+    #Returns user approval.
+    #False if not set,pending,approved,denied
+    def get_approval(self):
+        if not self.approval:
+            return False
+        return self.approval
 
     def status(self):
         success = False

--- a/authy/api/resources.py
+++ b/authy/api/resources.py
@@ -389,10 +389,8 @@ class OneTouchResponse(Instance):
         return self.uuid
 
     #Returns user approval.
-    #False if not set,pending,approved,denied
+    #None,pending,approved,denied
     def get_approval(self):
-        if not self.approval:
-            return False
         return self.approval
 
     def status(self):

--- a/tests/test_one_touch.py
+++ b/tests/test_one_touch.py
@@ -40,7 +40,6 @@ class OneTouchTest(unittest.TestCase):
         self.assertNotEqual(self.resource.get_approval_status(touch.get_uuid()).status(), False)
         self.assertEqual(self.resource.get_approval_status(touch.get_uuid()).get_approval(), 'pending')
 
-
     def test_send_request_with_minimum_data(self):
         user_id = test_helper.AUTH_ID_A
         message = "Login requested for a CapTrade Bank account."

--- a/tests/test_one_touch.py
+++ b/tests/test_one_touch.py
@@ -38,6 +38,8 @@ class OneTouchTest(unittest.TestCase):
         self.assertEqual(touch.errors(), {})
         self.assertIsNotNone(touch.get_uuid())
         self.assertNotEqual(self.resource.get_approval_status(touch.get_uuid()).status(), False)
+        self.assertEqual(self.resource.get_approval_status(touch.get_uuid()).get_approval(), 'pending')
+
 
     def test_send_request_with_minimum_data(self):
         user_id = test_helper.AUTH_ID_A
@@ -49,8 +51,9 @@ class OneTouchTest(unittest.TestCase):
         self.assertEqual(touch.errors(), {})
         self.assertIsNotNone(touch.get_uuid())
         self.assertNotEqual(self.resource.get_approval_status(touch.get_uuid()).status(), False)
+        self.assertEqual(self.resource.get_approval_status(touch.get_uuid()).get_approval(), 'pending')
 
-    def test_send_request_with_balnk_userId(self):
+    def test_send_request_with_blank_userId(self):
         user_id = ''
         message = "Login requested for a CapTrade Bank account."
         seconds_to_expire = 120
@@ -71,7 +74,7 @@ class OneTouchTest(unittest.TestCase):
         except AuthyException as e:
             self.assertEqual(str(e), "Invalid authy id, user id is requred and must be an integer value.")
 
-    def test_send_request_with_balnk_message(self):
+    def test_send_request_with_blank_message(self):
         user_id = test_helper.AUTH_ID_A
         message = ''
         seconds_to_expire = 120


### PR DESCRIPTION
Added a method to get user approval status
Updated readme to clarify that approval_status.status() should not be used for user approval status.