### PR TITLE
Add code_length support for phones.verification_start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ docs/build
 *.py[co]
 *.swp
 venv/
+env/
+.DS_Store
 
 # pyenv
 .python-version

--- a/authy/api/resources.py
+++ b/authy/api/resources.py
@@ -314,12 +314,14 @@ class Phone(Instance):
 
 class Phones(Resource):
 
-    def verification_start(self, phone_number, country_code, via='sms', locale=None):
+    def verification_start(self, phone_number, country_code, via='sms',
+                           locale=None, code_length=4):
         """
         :param string phone_number: stored in your databse or you provided while creating new user.
         :param string country_code: stored in your databse or you provided while creating new user.
         :param string via: verification method either sms or call
         :param string locale: optional default none
+        :param number code_length: optional default 4
         :return:
         """
 
@@ -334,6 +336,14 @@ class Phones(Resource):
 
         if locale:
             options['locale'] = locale
+
+        try:
+            cl = int(code_length)
+            if cl < 4 or cl > 10:
+                raise ValueError
+            options['code_length'] = cl
+        except ValueError:
+            raise AuthyFormatException("Invalid code_length. Expected numeric value from 4-10.")
 
         resp = self.post("/protected/json/phones/verification/start", options)
         return Phone(self, resp)

--- a/tests/test_phones.py
+++ b/tests/test_phones.py
@@ -7,7 +7,8 @@ else:
     import unittest
 
 from mockito import when, mock
-from authy import AuthyException
+
+from authy import AuthyException, AuthyFormatException
 from authy.api import AuthyApiClient
 from authy.api.resources import Phones
 from authy.api.resources import Phone
@@ -33,6 +34,39 @@ class PhonesTest(unittest.TestCase):
         phone = self.phones.verification_start(self.phone_number, self.country_code)
         self.assertTrue(phone.ok(), msg="errors: {0}".format(phone.errors()))
         self.assertEquals(phone['message'], 'Text message sent to +1 305-456-2345.')
+
+    def test_verification_start_with_code_length(self):
+        phone = self.phones.verification_start(self.phone_number, self.country_code,
+                                               code_length=7)
+        self.assertTrue(phone.ok(), msg="errors: {0}".format(phone.errors()))
+        self.assertRegexpMatches(phone['message'], 'Text message sent')
+
+    def test_verification_start_with_str_code_length(self):
+        phone = self.phones.verification_start(self.phone_number, self.country_code,
+                                               code_length='7')
+        self.assertTrue(phone.ok(), msg="errors: {0}".format(phone.errors()))
+        self.assertRegexpMatches(phone['message'], 'Text message sent')
+
+    def test_verification_start_with_non_numeric_code_length(self):
+        self.assertRaises(AuthyFormatException,
+                          self.phones.verification_start,
+                          self.phone_number,
+                          self.country_code,
+                          code_length='foo')
+
+    def test_verification_start_with_too_short_code_length(self):
+        self.assertRaises(AuthyFormatException,
+                          self.phones.verification_start,
+                          self.phone_number,
+                          self.country_code,
+                          code_length=2)
+
+    def test_verification_start_with_too_long_code_length(self):
+        self.assertRaises(AuthyFormatException,
+                          self.phones.verification_start,
+                          self.phone_number,
+                          self.country_code,
+                          code_length=12)
 
     def test_verification_check_incorrect_code(self):
         when(self.phones).verification_check(self.phone_number, self.country_code, '1234').thenReturn(


### PR DESCRIPTION
Fixes https://github.com/authy/authy-python/issues/35

@AdrianaPineda - I tested this locally, but is there a way to validate the code that's sent? I'm not sure how the sandbox-api in the unit tests works.

For example, this test doesn't actually check that the code is 7 digits, just that that doesn't fail: https://github.com/authy/authy-python/compare/master...robinske:codelength?expand=1#diff-2137eef954e8722aa5cc92545ea6fe9fR37