### PR TITLE
Coerced token to string to allow for length comparison

### DIFF
--- a/authy/api/resources.py
+++ b/authy/api/resources.py
@@ -273,7 +273,7 @@ class Tokens(Resource):
         self.__validate_digit(token, "Invalid Token. Only digits accepted.")
         self.__validate_digit(
             device_id, "Invalid Authy id. Only digits accepted.")
-        length = len(token)
+        length = len(str(token))
         if length < MIN_TOKEN_SIZE or length > MAX_TOKEN_SIZE:
             raise AuthyFormatException("Invalid Token. Unexpected length.")
 


### PR DESCRIPTION
When using the `authy_api.tokens.verify(authy_id, token)` method I was receiving a `TypeError: object of type 'int' has no len()`. 

I went in and wrapped the token in a `str()` after the token was validated as an integer. The tests still pass and I'm now able to verify the user token in my app.

Let me know if you need any more information! 